### PR TITLE
Add settings for userinput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ node_modules/
 npm-debug.log
 build/
 test-session/
-e2e-tests-out/
 .swc/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,3 @@
 npx lint-staged
 npx tsc
 npm test
-npx tsc -p e2e-tests/tsconfig.json

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { About } from 'app/pages/About'
 import { Game } from 'app/pages/Game'
+import { Settings } from 'app/pages/Settings'
 import { Navbar } from 'components/Navbar'
 import { useAppConfig } from 'hooks/useAppConfig'
 import {
@@ -11,12 +12,14 @@ import {
 
 export const App = () => {
 	const { basename } = useAppConfig()
+
 	return (
 		<Router basename={basename}>
 			<Navbar />
 			<Routes>
 				<Route index element={<Navigate to="/game" />} />
 				<Route path="/game" element={<Game />} />
+				<Route path="/settings" element={<Settings />} />
 				<Route path="/about" element={<About />} />
 			</Routes>
 		</Router>

--- a/src/app/pages/Settings.tsx
+++ b/src/app/pages/Settings.tsx
@@ -1,0 +1,56 @@
+import { Main } from 'components/Main'
+import React, { useState } from 'react'
+
+export const Settings = () => {
+	const [accessKey, setAccessKey] = useState<string | null>(null)
+	const [privateAccessKey, setprivateAccessKey] = useState<string | null>(null)
+
+	const onSubmitAccessKey = () => {
+		localStorage.setItem('accessKey', accessKey ?? '')
+	}
+	const onSubmitPrivateAccessKey = () => {
+		localStorage.setItem('privateAccessKey', privateAccessKey ?? '')
+	}
+
+	return (
+		<Main>
+			<div className="card">
+				<div className="card-header">User input</div>
+				<div className="card-body">
+					<p>This page is used for user input for connecting to AWS.</p>
+					<p>
+						Please enter your <code>AWS ACCESS KEY ID</code>:<br></br>
+						<input
+							type="text"
+							placeholder={localStorage.getItem('accessKey') ?? ''}
+							name="awsAccessKeyId"
+							onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+								setAccessKey(e.target.value)
+							}
+						/>
+						<button background-color="#e681b3" onClick={onSubmitAccessKey}>
+							SUBMIT
+						</button>
+					</p>
+					<p>
+						Please enter your <code>AWS SECRET ACCESS KEY</code>:<br></br>
+						<input
+							type="text"
+							placeholder={localStorage.getItem('privateAccessKey') ?? ''}
+							name="awsPrivateAccessKey"
+							onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+								setprivateAccessKey(e.target.value)
+							}
+						/>
+						<button
+							background-color="#e681b3"
+							onClick={onSubmitPrivateAccessKey}
+						>
+							SUBMIT
+						</button>
+					</p>
+				</div>
+			</div>
+		</Main>
+	)
+}

--- a/src/app/pages/Settings.tsx
+++ b/src/app/pages/Settings.tsx
@@ -28,9 +28,7 @@ export const Settings = () => {
 								setAccessKey(e.target.value)
 							}
 						/>
-						<button background-color="#e681b3" onClick={onSubmitAccessKey}>
-							SUBMIT
-						</button>
+						<button onClick={onSubmitAccessKey}>SUBMIT</button>
 					</p>
 					<p>
 						Please enter your <code>AWS SECRET ACCESS KEY</code>:<br></br>
@@ -42,12 +40,7 @@ export const Settings = () => {
 								setprivateAccessKey(e.target.value)
 							}
 						/>
-						<button
-							background-color="#e681b3"
-							onClick={onSubmitPrivateAccessKey}
-						>
-							SUBMIT
-						</button>
+						<button onClick={onSubmitPrivateAccessKey}>SUBMIT</button>
 					</p>
 				</div>
 			</div>

--- a/src/components/FeatherIcon.tsx
+++ b/src/components/FeatherIcon.tsx
@@ -339,6 +339,10 @@ export const InfoIcon = (options?: TypedIconOptions) => (
 	<FeatherIcon {...options} title="center" type="info" />
 )
 
+export const SettingsIcon = (options?: TypedIconOptions) => (
+	<FeatherIcon {...options} title="center" type="settings" />
+)
+
 export const IconWithText: FunctionComponent<PropsWithChildren<any>> = ({
 	children,
 	...rest

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,9 @@
-import { GameIcon, IconWithText, InfoIcon } from 'components/FeatherIcon'
+import {
+	GameIcon,
+	IconWithText,
+	InfoIcon,
+	SettingsIcon,
+} from 'components/FeatherIcon'
 import styles from 'components/Navbar.module.css'
 import { useAppConfig } from 'hooks/useAppConfig'
 import { useState } from 'react'
@@ -56,6 +61,13 @@ export const Navbar = () => {
 									<Link className="nav-link" to="/game" onClick={close}>
 										<IconWithText>
 											<GameIcon /> Game
+										</IconWithText>
+									</Link>
+								</li>
+								<li className="nav-item">
+									<Link className="nav-link" to="/settings" onClick={close}>
+										<IconWithText>
+											<SettingsIcon /> Settings
 										</IconWithText>
 									</Link>
 								</li>


### PR DESCRIPTION
Adds a new page for settings where the user can input their aws credentials. The credentials are stored in localstorage in the browser, and are also displayed in the input as a placeholder when set.

Closes #8 